### PR TITLE
fix: Change iOS header import style to work with latest Expo

### DIFF
--- a/ios/RNAlipay.h
+++ b/ios/RNAlipay.h
@@ -1,8 +1,4 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNAlipay : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Expo 44.0 限制了 RN header 的 import 方式，不改成新的 import 方式会有编译问题，详见 https://github.com/expo/expo/issues/15622#issuecomment-997141629